### PR TITLE
fix(API): Use new values for tertiary parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import northCrs from 'leaflet-nearmap/crs/north';
 import northLayer from 'leaflet-nearmap/layers/north';
 
 const ApiKey = 'YOUR_API_KEY';
-const UrlTemplate = `https://api.nearmap.com/tiles/v3/{layer}/{z}/{x}/{y}.img?tertiary=default&apikey=${ApiKey}`;
+const UrlTemplate = `https://api.nearmap.com/tiles/v3/{layer}/{z}/{x}/{y}.img?tertiary=satellite&apikey=${ApiKey}`;
 
 const map = leaflet.map('mapid', {
   crs: northCrs,

--- a/examples/index.js
+++ b/examples/index.js
@@ -61,7 +61,7 @@ function initButtons(map, url) {
 function init() {
   // API config
   const demoKey ='Yzc2MjEzMWUtY2Q4YS00NTM2LTgyMDgtMDljZjI2YTdhMTMz';
-  const url = `https://api.nearmap.com/tiles/v3/{layer}/{z}/{x}/{y}.img?tertiary=default&apikey=${demoKey}`;
+  const url = `https://api.nearmap.com/tiles/v3/{layer}/{z}/{x}/{y}.img?tertiary=satellite&apikey=${demoKey}`;
 
   // demo area that is available for demo API-key
   const lat = -34.915302;


### PR DESCRIPTION
Update URL template to use `tertiary=satellite` instead of `tertiary=default`.